### PR TITLE
Print stats while mining

### DIFF
--- a/skepticoin/scripts/mine.py
+++ b/skepticoin/scripts/mine.py
@@ -44,6 +44,7 @@ def main():
 
     start_time = datetime.now()
     start_balance = wallet.get_balance(coinstate) / Decimal(SASHIMI_PER_COIN)
+    balance = start_balance
     print("Wallet balance: %s skepticoin" % start_balance)
 
 
@@ -67,11 +68,10 @@ def main():
                     uptime = now - start_time
                     uptime_str = str(uptime).split(".")[0]
 
-                    balance = wallet.get_balance(coinstate) / Decimal(SASHIMI_PER_COIN)
                     mined = balance - start_balance
                     mine_speed = (float(mined) / uptime.total_seconds()) * 60 * 60
 
-                    print(f"{now_str} | uptime: {uptime_str} | {hashes:>2} hash/sec | mined: {mined:>3} SKE | {mine_speed:5.2f} SKE/h")
+                    print(f"{now_str} | uptime: {uptime_str} | {hashes:>2} hash/sec | mined: {mined:>3} SKEPTI | {mine_speed:5.2f} SKEPTI/h")
                     last_round_second = int(time())
                     hashes = 0
 
@@ -89,7 +89,8 @@ def main():
             with open(Path('chain') / block_filename(block), 'wb') as f:
                 f.write(block.serialize())
             print("FOUND", block_filename(block))
-            print("Wallet balance: %s skepticoin" % (wallet.get_balance(coinstate) / Decimal(SASHIMI_PER_COIN)))
+            balance = (wallet.get_balance(coinstate) / Decimal(SASHIMI_PER_COIN))
+            print("Wallet balance: %s skepticoin" % balance)
 
             thread.local_peer.chain_manager.set_coinstate(coinstate)
             thread.local_peer.network_manager.broadcast_block(block)

--- a/skepticoin/scripts/mine.py
+++ b/skepticoin/scripts/mine.py
@@ -47,7 +47,6 @@ def main():
     balance = start_balance
     print("Wallet balance: %s skepticoin" % start_balance)
 
-
     print("Starting mining: A repeat minter")
 
     try:
@@ -71,7 +70,8 @@ def main():
                     mined = balance - start_balance
                     mine_speed = (float(mined) / uptime.total_seconds()) * 60 * 60
 
-                    print(f"{now_str} | uptime: {uptime_str} | {hashes:>2} hash/sec | mined: {mined:>3} SKEPTI | {mine_speed:5.2f} SKEPTI/h")
+                    print(f"{now_str} | uptime: {uptime_str} | {hashes:>2} hash/sec" +
+                          f" | mined: {mined:>3} SKEPTI | {mine_speed:5.2f} SKEPTI/h")
                     last_round_second = int(time())
                     hashes = 0
 

--- a/skepticoin/scripts/mine.py
+++ b/skepticoin/scripts/mine.py
@@ -44,6 +44,9 @@ def main():
 
     start_time = datetime.now()
     start_balance = wallet.get_balance(coinstate) / Decimal(SASHIMI_PER_COIN)
+    print("Wallet balance: %s skepticoin" % start_balance)
+
+
     print("Starting mining: A repeat minter")
 
     try:


### PR DESCRIPTION
Inspired by PR #14. 
Prints stats every second, like below:
* current timestamp
* uptime of miner
* hash speed
* SKE earned this session
* SKE earned on average per hour

Below lines are 82 characters which should be acceptable.
The last 3 columns are padded with spaces, but over time columns will may become wider, this happens rarely though.

```
Starting main loop                                                             
2021-05-09 14:49:37 | uptime: 0:00:00 | 10 hash/sec | mined:   0 SKE |  0.00 SKE/h
2021-05-09 14:49:38 | uptime: 0:00:01 | 12 hash/sec | mined:   0 SKE |  0.00 SKE/h
2021-05-09 14:49:39 | uptime: 0:00:02 | 13 hash/sec | mined:   0 SKE |  0.00 SKE/h
2021-05-09 14:49:40 | uptime: 0:00:03 | 12 hash/sec | mined:   0 SKE |  0.00 SKE/h
2021-05-09 14:49:41 | uptime: 0:00:04 | 13 hash/sec | mined:   0 SKE |  0.00 SKE/h
2021-05-09 14:49:42 | uptime: 0:00:05 | 12 hash/sec | mined:   0 SKE |  0.00 SKE/h
2021-05-09 14:49:43 | uptime: 0:00:06 | 13 hash/sec | mined:   0 SKE |  0.00 SKE/h    
2021-05-09 14:49:44 | uptime: 0:00:07 | 12 hash/sec | mined:   0 SKE |  0.00 SKE/h    
2021-05-09 14:49:45 | uptime: 0:00:08 | 13 hash/sec | mined:   0 SKE |  0.00 SKE/h
```