### PR TITLE
Let Miner do little more than scrypt

### DIFF
--- a/skepticoin/mining.py
+++ b/skepticoin/mining.py
@@ -18,7 +18,7 @@ from skepticoin.wallet import Wallet, save_wallet
 from skepticoin.utils import block_filename
 from skepticoin.cheating import MAX_KNOWN_HASH_HEIGHT
 from time import time
-from multiprocessing import Process, Queue, synchronize
+from multiprocessing import Process, Queue
 from skepticoin.scripts.utils import (
     initialize_peers_file,
     create_chain_dir,
@@ -31,8 +31,8 @@ from skepticoin.scripts.utils import (
 )
 
 
-def run_miner(args: Any, wallet_lock: synchronize.Lock, queue: Queue, miner_id: int) -> None:
-    miner = Miner(args, wallet_lock, queue, miner_id)
+def run_miner(args: Any, send_queue: Queue, recv_queue: Queue, miner_id: int) -> None:
+    miner = Miner(args, send_queue, recv_queue, miner_id)
     miner()
 
 

--- a/skepticoin/mining.py
+++ b/skepticoin/mining.py
@@ -63,7 +63,7 @@ class Miner:
 
     def __call__(self) -> None:
         configure_logging_from_args(self.args)
-        self.send_message("info", "Starting mining: A repeat minter")
+        print(f"miner {self.miner_id}: starting a repeat minter")
 
         nonce = random.randrange(1 << 32)
 
@@ -76,10 +76,7 @@ class Miner:
                 nonce = (nonce + 1) % (1 << 32)
 
         except KeyboardInterrupt:
-            self.send_message("info", "KeyboardInterrupt")
-
-        finally:
-            self.send_message("info", "Done; waiting for Python-exit")
+            print(f"miner {self.miner_id} shutting down")
 
 
 class MinerWatcher:
@@ -181,7 +178,6 @@ class MinerWatcher:
         miner_id, message_type, data = queue_item
 
         message_handlers: Dict[str, Callable[[int, Any], None]] = {
-            "info": self.handle_info_message,
             "request_scrypt_input": self.handle_request_scrypt_input_message,
             "scrypt_output": self.handle_scrypt_output_message,
         }
@@ -218,9 +214,6 @@ class MinerWatcher:
             self.hash_stats[timestamp] = 0
 
         self.hash_stats[timestamp] += 1
-
-    def handle_info_message(self, miner_id: int, data: str) -> None:
-        print(f"miner {miner_id:2}: {data}")
 
     def handle_scrypt_output_message(self, miner_id: int, data: bytes) -> None:
         summary_hash: bytes = data


### PR DESCRIPTION
In this PR I want to:
* Have one NetworkingThread: in MinerWatcher
* Load the chain once: in MinerWatcher
* Handle the wallet once: in ... you guessed it

Effectively, Miner should be stripped to:
* calling scrypt
* facilitating the call to scrypt (including dealing with its return value)
* any other bookkeeping that cannot be done in MinerWatcher

At time of posting, this PR is ahead of my branches in #16 and #26, so those should be merged before this PR.
Furthermore, the implementation is not done yet.