### PR TITLE
fix #36: limit to 64 selectors on Windows

### DIFF
--- a/skepticoin/networking/peer.py
+++ b/skepticoin/networking/peer.py
@@ -8,6 +8,7 @@ from ipaddress import IPv6Address
 from threading import Lock
 from time import time
 from typing import Dict, List, Optional, Set, Tuple
+from sys import platform
 
 from skepticoin.coinstate import CoinState
 import random
@@ -889,6 +890,10 @@ class LocalPeer:
 
     def start_outgoing_connection(self, disconnected_peer: DisconnectedRemotePeer) -> None:
         self.logger.info("%15s LocalPeer.start_outgoing_connection()" % disconnected_peer.host)
+
+        if platform == 'win32' and len(self.selector.get_map()) >= 64:
+            # the client no longer works at all in Windows once we go over 64 connected peers
+            return
 
         server_addr = (disconnected_peer.host, disconnected_peer.port)
 


### PR DESCRIPTION
The skepticoin client has not been working at all on Windows for the last few days. (See #36)
This quick fix is probably not ideal but at least it restores functionality for now.