### PR TITLE
Download initial peers from multiple urls

### DIFF
--- a/peer_urls.txt
+++ b/peer_urls.txt
@@ -1,0 +1,2 @@
+https://pastebin.com/raw/CcfPX9mS
+http://skepticoin.s3.amazonaws.com/peers.json

--- a/peer_urls.txt
+++ b/peer_urls.txt
@@ -1,2 +1,2 @@
 https://pastebin.com/raw/CcfPX9mS
-http://skepticoin.s3.amazonaws.com/peers.json
+https://skepticoin.s3.amazonaws.com/peers.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest-mock
 immutables
 scrypt
 ecdsa
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ pytest-mock
 immutables
 scrypt
 ecdsa
-requests


### PR DESCRIPTION
This PR was implemented after discussion in #48 

When running this project for the first time peers are downloaded and saved into `peers.json`.
Subsequent runs use this file.

This PR adds that we download from multiple sources and merge them into this file.
The sources to download from are in the `peer_urls.txt` file.
