### PR TITLE
Workaround for #45: Prevent error from too many open files on non-windows platforms

### DIFF
--- a/skepticoin/mining.py
+++ b/skepticoin/mining.py
@@ -101,6 +101,8 @@ class MinerWatcher:
         self.public_key: bytes
 
     def __call__(self) -> None:
+        configure_logging_from_args(self.args)
+
         create_chain_dir()
         self.coinstate = read_chain_from_disk()
 

--- a/skepticoin/networking/peer.py
+++ b/skepticoin/networking/peer.py
@@ -8,7 +8,7 @@ from ipaddress import IPv6Address
 from threading import Lock
 from time import time
 from typing import Dict, List, Optional, Set, Tuple
-from sys import platform
+import sys
 
 from skepticoin.coinstate import CoinState
 import random
@@ -65,6 +65,11 @@ MAGIC = b'MAJI'
 
 INCOMING = "INCOMING"
 OUTGOING = "OUTGOING"
+
+MAX_SELECTOR_SIZE_BY_PLATFORM: Dict[str, int] = {
+    "win32": 64,
+    "linux": 512,
+}
 
 
 def _new_context() -> int:
@@ -465,7 +470,11 @@ class ConnectedRemotePeer(RemotePeer):
             self.start_sending()
 
     def start_sending(self) -> None:
-        self.local_peer.selector.modify(self.sock, selectors.EVENT_READ | selectors.EVENT_WRITE, data=self)
+        try:
+            self.local_peer.selector.modify(self.sock, selectors.EVENT_READ | selectors.EVENT_WRITE, data=self)
+        except ValueError:
+            # TODO Invalid file descriptor: -1 happens here
+            pass
 
     def stop_sending(self) -> None:
         self.local_peer.selector.modify(self.sock, selectors.EVENT_READ, data=self)
@@ -886,8 +895,11 @@ class LocalPeer:
     def start_outgoing_connection(self, disconnected_peer: DisconnectedRemotePeer) -> None:
         self.logger.info("%15s LocalPeer.start_outgoing_connection()" % disconnected_peer.host)
 
-        if platform == 'win32' and len(self.selector.get_map()) >= 64:
-            # the client no longer works at all in Windows once we go over 64 connected peers
+        max_selector_map_size = MAX_SELECTOR_SIZE_BY_PLATFORM.get(sys.platform, 64)
+
+        if len(self.selector.get_map()) >= max_selector_map_size:
+            # We hit the platform-dependent limit of connected peers
+            # TODO this is actually a hack, find a proper solution
             return
 
         server_addr = (disconnected_peer.host, disconnected_peer.port)

--- a/skepticoin/networking/peer.py
+++ b/skepticoin/networking/peer.py
@@ -473,8 +473,7 @@ class ConnectedRemotePeer(RemotePeer):
         try:
             self.local_peer.selector.modify(self.sock, selectors.EVENT_READ | selectors.EVENT_WRITE, data=self)
         except ValueError:
-            # TODO Invalid file descriptor: -1 happens here
-            pass
+            self.local_peer.logger.error("%15s ConnectedRemotePeer.start_sending() ValueError" % (self.host))
 
     def stop_sending(self) -> None:
         self.local_peer.selector.modify(self.sock, selectors.EVENT_READ, data=self)


### PR DESCRIPTION
This is supposed to be a [Temporary Workaround™](https://i.pinimg.com/originals/dd/35/e1/dd35e16cf522309472ad6de54d3b25af.jpg).

This stops linux machines from connecting to more peers than 512.
I chose this number because my limit of open files is 1024 (`ulimit -n`) so I took half of it.

For platforms that are not linux or windows I'm resorting to the more conservative 64 open sockets.