### PR TITLE
peer logging improvements

### DIFF
--- a/skepticoin/mining.py
+++ b/skepticoin/mining.py
@@ -173,8 +173,12 @@ class MinerWatcher:
         hashes = self.hash_stats[timestamp]
 
         mine_speed = (float(mined) / uptime.total_seconds()) * 60 * 60
+
+        n_peers = len(self.network_thread.local_peer.network_manager.get_active_peers())
+
         print(f"{now_str} | uptime: {uptime_str} | {hashes:>3} hash/sec" +
-              f" | mined: {mined:>3} SKEPTI | {mine_speed:5.2f} SKEPTI/h")
+              f" | mined: {mined:>3} SKEPTI | {mine_speed:5.2f} SKEPTI/h" +
+              f" | {n_peers:3d} peers")
 
     def send_message(self, miner_id: int, message_type: str, data: Any) -> None:
         self.send_queues[miner_id].put((message_type, data))

--- a/skepticoin/networking/local_peer.py
+++ b/skepticoin/networking/local_peer.py
@@ -146,7 +146,6 @@ class LocalPeer:
             self.logger.info("%15s Error while disconnecting %s" % ("", e))
 
     def start_outgoing_connection(self, disconnected_peer: DisconnectedRemotePeer) -> None:
-        self.logger.info("%15s LocalPeer.start_outgoing_connection()" % disconnected_peer.host)
 
         max_selector_map_size = MAX_SELECTOR_SIZE_BY_PLATFORM.get(sys.platform, 64)
 
@@ -154,6 +153,8 @@ class LocalPeer:
             # We hit the platform-dependent limit of connected peers
             # TODO this is actually a hack, find a proper solution
             return
+
+        self.logger.info("%15s LocalPeer.start_outgoing_connection()" % disconnected_peer.host)
 
         server_addr = (disconnected_peer.host, disconnected_peer.port)
 

--- a/skepticoin/networking/manager.py
+++ b/skepticoin/networking/manager.py
@@ -97,7 +97,7 @@ class NetworkManager(Manager):
             if remote_peer.hello_received:
                 self.disconnected_peers[key] = remote_peer.as_disconnected()
             else:
-                print('Bad Peer (disconnected without hello): ' + remote_peer.host)
+                self.local_peer.logger.info('%15s Disconnected without hello - Bad Peer' % remote_peer.host)
                 self.local_peer.disk_interface.overwrite_peers(list(self.connected_peers.values()))
 
         self._sanity_check()

--- a/skepticoin/networking/messages.py
+++ b/skepticoin/networking/messages.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import struct
 from ipaddress import IPv6Address
 from typing import Dict, List, Type, BinaryIO
@@ -71,7 +72,9 @@ class MessageHeader(Serializable):
         f.write(b'\x00' * 32)  # reserved space for later versions
 
     def format(self) -> str:
-        return "t%010d-i%010d-r%010d-c%020d" % (self.timestamp, self.id, self.in_response_to, self.context)
+        return "ts: %s, id: %010d, req: %010d, ctx: %020d" % (
+            datetime.datetime.fromtimestamp(self.timestamp).astimezone().isoformat(),
+            self.id, self.in_response_to, self.context)
 
 
 class Message(Serializable):

--- a/skepticoin/scripts/utils.py
+++ b/skepticoin/scripts/utils.py
@@ -173,6 +173,7 @@ def start_networking_peer_in_background(
 
 def configure_logging_for_file() -> None:
     log_filename = Path(tempfile.gettempdir()) / ("skepticoin-networking-%s.log" % int(time()))
+    print('Logging to file: %s' % log_filename)
     FORMAT = '%(asctime)s %(message)s'
     logging.basicConfig(format=FORMAT, stream=open(log_filename, "w"), level=logging.INFO)
 


### PR DESCRIPTION
This PR consists of several improvements to logging of peer network code.
Functionality (other than logging) is not affected.

add number of connected peers to the stats_line
log peer disconnection to the network log instead of print()
log some additional info to try to understand peering code
print the name of the logfile
print stack trace on ConnectedRemotePeer.start_sending() error
add more details to peering logs
log the send_buffer and send_backlog sizes