### PR TITLE
improve(fix) handling of corrupted peers.json and 127.0.0.1 "leakage"

### DIFF
--- a/skepticoin/mining.py
+++ b/skepticoin/mining.py
@@ -20,7 +20,6 @@ from skepticoin.cheating import MAX_KNOWN_HASH_HEIGHT
 from time import time
 from multiprocessing import Process, Queue
 from skepticoin.scripts.utils import (
-    initialize_peers_file,
     create_chain_dir,
     read_chain_from_disk,
     open_or_init_wallet,
@@ -110,7 +109,6 @@ class MinerWatcher:
         self.start_balance = self.wallet.get_balance(self.coinstate) / Decimal(SASHIMI_PER_COIN)
         self.balance = self.start_balance
 
-        initialize_peers_file()
         self.network_thread = start_networking_peer_in_background(self.args, self.coinstate)
 
         self.network_thread.local_peer.show_stats()

--- a/skepticoin/networking/disk_interface.py
+++ b/skepticoin/networking/disk_interface.py
@@ -1,0 +1,81 @@
+import os
+from typing import Dict, List, Set, Tuple
+from skepticoin.utils import block_filename
+from skepticoin.datatypes import Block, Transaction
+from skepticoin.networking.remote_peer import (
+    ConnectedRemotePeer, DisconnectedRemotePeer, OUTGOING, load_peers_from_list
+)
+import json
+import urllib.request
+from skepticoin.humans import human
+
+
+PEER_URLS: List[str] = [
+    "https://pastebin.com/raw/CcfPX9mS",
+    "https://skepticoin.s3.amazonaws.com/peers.json",
+]
+
+
+def load_peers_from_network() -> List[Tuple[str, int, str]]:
+
+    all_peers: Set[Tuple[str, int, str]] = set()
+
+    for url in PEER_URLS:
+        print(f"downloading {url}")
+
+        with urllib.request.urlopen(url, timeout=1) as resp:
+            try:
+                peers = json.loads(resp.read())
+            except ValueError:
+                continue
+
+            for peer in peers:
+                if len(peer) != 3:
+                    continue
+
+                all_peers.add(tuple(peer))  # type: ignore
+
+    print("New peers.json will be created")
+    return list(all_peers)
+
+
+class DiskInterface:
+    """Catch-all for writing to and reading from disk, factored out to facilitate testing."""
+
+    def __init__(self) -> None:
+        self.last_saved_peers: List[Tuple[str, int, str]] = []
+
+    def load_peers(self) -> Dict[Tuple[str, int, str], DisconnectedRemotePeer]:
+        try:
+            db: List[Tuple[str, int, str]] = [tuple(li) for li in json.loads(open("peers.json").read())]  # type: ignore
+        except Exception as e:
+            print('Ignoring corrupted or missing peers.json: ' + str(e))
+            db = load_peers_from_network()
+
+        print('Loading initial list of %d peers' % len(db))
+        return load_peers_from_list(db)
+
+    def write_peers(self, peers: Dict[Tuple[str, int, str], ConnectedRemotePeer]) -> None:
+        db = [(remote_peer.host, remote_peer.port, remote_peer.direction)
+              for remote_peer in peers.values()
+              if (remote_peer.direction == OUTGOING and remote_peer.hello_received)]
+
+        db.sort()
+
+        if self.last_saved_peers != db:
+
+            if db:
+                with open("peers.json", "w") as f:
+                    json.dump(db, f, indent=4)
+            else:
+                os.remove("peers.json")
+
+            self.last_saved_peers = db
+
+    def save_block(self, block: Block) -> None:
+        with open('chain/%s' % block_filename(block), 'wb') as f:
+            f.write(block.serialize())
+
+    def save_transaction_for_debugging(self, transaction: Transaction) -> None:
+        with open("/tmp/%s.transaction" % human(transaction.hash()), 'wb') as f:
+            f.write(transaction.serialize())

--- a/skepticoin/networking/manager.py
+++ b/skepticoin/networking/manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from skepticoin.networking.local_peer import DiskInterface
 
 import traceback
 from threading import Lock
@@ -43,11 +44,12 @@ class Manager:
 
 class NetworkManager(Manager):
 
-    def __init__(self, local_peer: LocalPeer):
+    def __init__(self, local_peer: LocalPeer, disk_interface: DiskInterface = DiskInterface()) -> None:
         self.local_peer = local_peer
         self.my_addresses: Set[Tuple[str, int]] = set()
         self.connected_peers: Dict[Tuple[str, int, str], ConnectedRemotePeer] = {}
         self.disconnected_peers: Dict[Tuple[str, int, str], DisconnectedRemotePeer] = {}
+        self.disk_interface = disk_interface
 
     def _sanity_check(self) -> None:
         for key in self.disconnected_peers:
@@ -98,7 +100,7 @@ class NetworkManager(Manager):
                 self.disconnected_peers[key] = remote_peer.as_disconnected()
             else:
                 self.local_peer.logger.info('%15s Disconnected without hello - Bad Peer' % remote_peer.host)
-                self.local_peer.disk_interface.overwrite_peers(list(self.connected_peers.values()))
+                self.disk_interface.write_peers(self.connected_peers)
 
         self._sanity_check()
 

--- a/skepticoin/networking/remote_peer.py
+++ b/skepticoin/networking/remote_peer.py
@@ -3,14 +3,13 @@ from io import BytesIO
 import traceback
 
 from ipaddress import IPv6Address
-
-from typing import TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from skepticoin.networking.local_peer import LocalPeer
 
 from time import time
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import struct
 import socket
@@ -41,10 +40,8 @@ from .messages import (
     InventoryMessage,
     InventoryItem,
 )
-import json
 from skepticoin.__version__ import __version__
 import random
-
 
 LISTENING_SOCKET = "LISTENING_SOCKET"
 IRRELEVANT = "IRRELEVANT"  # TODO don't use a string for a port number
@@ -62,15 +59,6 @@ def load_peers_from_list(
         (host, port, direction): DisconnectedRemotePeer(host, port, direction, None)
         for (host, port, direction) in lst
     }
-
-
-def load_peers() -> Dict[Tuple[str, int, str], DisconnectedRemotePeer]:
-    try:
-        db = [tuple(li) for li in json.loads(open("peers.json").read())]
-    except Exception:
-        db = []
-
-    return load_peers_from_list(db)  # type: ignore
 
 
 def _new_context() -> int:
@@ -330,7 +318,7 @@ class ConnectedRemotePeer(RemotePeer):
             self.local_peer.network_manager.my_addresses.add((self.host, self.port))
             self.local_peer.disconnect(self, "connection to self")
 
-        self.local_peer.disk_interface.overwrite_peers(list(self.local_peer.network_manager.connected_peers.values()))
+        self.local_peer.disk_interface.write_peers(self.local_peer.network_manager.connected_peers)
 
     def handle_get_blocks_message_received(self, header: MessageHeader, message: GetBlocksMessage) -> None:
         self.local_peer.logger.info("%15s ConnectedRemotePeer.handle_get_blocks_message_received()" % self.host)

--- a/skepticoin/networking/threading.py
+++ b/skepticoin/networking/threading.py
@@ -18,6 +18,7 @@ class NetworkingThread(Thread):
 
         self.local_peer = LocalPeer(disk_interface=disk_interface)
         self.local_peer.chain_manager.set_coinstate(coinstate)
+        self.local_peer.network_manager.disconnected_peers = disk_interface.load_peers()
 
     def run(self) -> None:
         if self.port is not None:

--- a/skepticoin/scripts/repl.py
+++ b/skepticoin/scripts/repl.py
@@ -10,7 +10,6 @@ import skepticoin.humans
 from skepticoin.params import SASHIMI_PER_COIN
 from skepticoin.scripts.utils import (
     configure_logging_from_args,
-    initialize_peers_file,
     create_chain_dir,
     read_chain_from_disk,
     open_or_init_wallet,
@@ -36,7 +35,6 @@ def main() -> None:
     create_chain_dir()
     coinstate = read_chain_from_disk()
     wallet = open_or_init_wallet()
-    initialize_peers_file()
     thread = start_networking_peer_in_background(args, coinstate)
     thread.local_peer.show_stats()
 

--- a/skepticoin/scripts/run.py
+++ b/skepticoin/scripts/run.py
@@ -1,7 +1,6 @@
 import traceback
 
 from .utils import (
-    initialize_peers_file,
     create_chain_dir,
     read_chain_from_disk,
     open_or_init_wallet,
@@ -25,7 +24,6 @@ def main() -> None:
     create_chain_dir()
     coinstate = read_chain_from_disk()
     wallet = open_or_init_wallet()
-    initialize_peers_file()
     thread = start_networking_peer_in_background(args, coinstate)
     thread.local_peer.show_stats()
 

--- a/skepticoin/scripts/send.py
+++ b/skepticoin/scripts/send.py
@@ -10,7 +10,6 @@ from skepticoin.consensus import (
 )
 
 from .utils import (
-    initialize_peers_file,
     create_chain_dir,
     read_chain_from_disk,
     open_or_init_wallet,
@@ -38,7 +37,6 @@ def main() -> None:
     create_chain_dir()
     coinstate = read_chain_from_disk()
     wallet = open_or_init_wallet()
-    initialize_peers_file()
     thread = start_networking_peer_in_background(args, coinstate)
 
     try:

--- a/tests/networking/test_integration.py
+++ b/tests/networking/test_integration.py
@@ -3,6 +3,7 @@ The general theme of these tests is: let's do some end-to-end tests, so we at le
 the most obvious of mistakes.
 """
 
+from typing import Dict, Tuple
 import pytest
 from time import time
 import logging
@@ -15,7 +16,7 @@ from skepticoin.datatypes import Block, Transaction, Input, Output, OutputRefere
 from skepticoin.coinstate import CoinState
 from skepticoin.networking.messages import InventoryMessage
 from skepticoin.networking.threading import NetworkingThread
-from skepticoin.networking.remote_peer import load_peers_from_list
+from skepticoin.networking.remote_peer import DisconnectedRemotePeer, load_peers_from_list
 
 CHAIN_TESTDATA_PATH = Path(__file__).parent.joinpath("../testdata/chain")
 
@@ -24,8 +25,11 @@ class FakeDiskInterface:
     def save_block(self, block):
         pass
 
-    def overwrite_peers(self, remote_peers):
+    def write_peers(self, remote_peers):
         pass
+
+    def load_peers(self) -> Dict[Tuple[str, int, str], DisconnectedRemotePeer]:
+        return {}
 
     def save_transaction_for_debugging(self, transaction):
         pass
@@ -71,7 +75,7 @@ def test_ibd_integration(caplog):
     try:
         start_time = time()
         while True:
-            if thread_b.local_peer.chain_manager.coinstate.head().height == 5:
+            if thread_b.local_peer.chain_manager.coinstate.head().height >= 5:
                 break
 
             if time() > start_time + 5:


### PR DESCRIPTION
This is a refactoring of the `DiskInterface` class, which as a side-effect fixes two different issues. Due to the fixes being side-effects of the refactoring,  it's not possible to split them further into two PRs:
- Moving the load_peers() into DiskInterface where it can be overridden in FakeDiskInterface during testing fixes the root cause of issue #84. (Note that it may take some time for bad peer lists to phase out from the "mainnet")
- Using the network peer URLs if the peers.json throws exception during load is a more robust solution for #28 under a variety of different root-causes, for example, process interrupted by Ctrl+C (I'm an impatient end-user!)
