### PR TITLE
fix issue #110: re-use public keys when mining runs out of them

### DIFF
--- a/skepticoin/scripts/repl.py
+++ b/skepticoin/scripts/repl.py
@@ -50,7 +50,7 @@ def main() -> None:
         }
 
         for module in [skepticoin.datatypes, skepticoin.networking.messages, skepticoin.signing, skepticoin.humans]:
-            for attr in module.__all__:  # type: ignore
+            for attr in module.__all__:
                 globals[attr] = getattr(module, attr)
 
         def configure(repl: PythonRepl) -> None:

--- a/skepticoin/wallet.py
+++ b/skepticoin/wallet.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import random
 from typing import Dict, List, Mapping, Set, TextIO
 
 import ecdsa
@@ -46,6 +47,9 @@ class Wallet:
         return public_key in self.keypairs
 
     def get_annotated_public_key(self, annotation: str) -> bytes:
+        if len(self.unused_public_keys) == 0:
+            print("WARNING: Re-using mining keys. Privacy may be reduced via statistical chain analysis.")
+            return random.choice(list(self.keypairs.keys()))
         public_key = self.unused_public_keys.pop()
         self.public_key_annotations[public_key] = annotation
         return public_key


### PR DESCRIPTION
This is an alternative proposal to PR #112 - fixes #110, partially fixes #117.

The problem with PR #112 was that people running miners on multiple computers would end up with coins they cannot access unless the generated keys are manually transferred back to a central wallet.

The idea here is to re-use public keys so mining can continue. This comes at a cost: over a long enough period of time, a statistical analysis will be able to correlate which coins were mined from the same wallet.

That's not great, but it's better than lost coins.

It's recommended that a future PR should expand default wallet sizes from 10,000 to some larger number. This PR will work great with this hypothetical future PR, as a larger wallet would make the above statistical analysis much less effective.