### PR TITLE
fix issue #118 - wrong balances in master branch

### DIFF
--- a/skepticoin/scripts/repl.py
+++ b/skepticoin/scripts/repl.py
@@ -50,7 +50,7 @@ def main() -> None:
         }
 
         for module in [skepticoin.datatypes, skepticoin.networking.messages, skepticoin.signing, skepticoin.humans]:
-            for attr in module.__all__:  # type: ignore
+            for attr in module.__all__:
                 globals[attr] = getattr(module, attr)
 
         def configure(repl: PythonRepl) -> None:

--- a/skepticoin/wallet.py
+++ b/skepticoin/wallet.py
@@ -87,7 +87,7 @@ class Wallet:
         return sum(
             coinstate.public_key_balances_by_hash[coinstate.current_chain_hash].get(  # type: ignore
                 SECP256k1PublicKey(pk), PKBalance(0, [])).value
-            for pk in self.public_key_annotations.keys()
+            for pk in self.keypairs.keys()
         )
 
 


### PR DESCRIPTION
Revert the usage of annotated keys, not compatible with using saved, shared, or restored (from backup) wallet.json files.

The issue that this fixes is only on the master branch, not released yet.