### PR TITLE
fix #118 balance calculation issues

### DIFF
--- a/skepticoin/scripts/balance.py
+++ b/skepticoin/scripts/balance.py
@@ -27,7 +27,7 @@ def main() -> None:
     # blockchain to know the most current balance.
     thread = start_networking_peer_in_background(args, coinstate)
 
-    wait_for_fresh_chain(thread)
+    wait_for_fresh_chain(thread, freshness=300)
     coinstate = thread.local_peer.chain_manager.coinstate
     print("Chain up to date")
 

--- a/skepticoin/scripts/utils.py
+++ b/skepticoin/scripts/utils.py
@@ -30,14 +30,14 @@ def check_chain_dir() -> None:
         print('Your ./chain/ directory is no longer needed: please delete it to stop this reminder.')
 
 
-def wait_for_fresh_chain(thread: NetworkingThread) -> None:
+def wait_for_fresh_chain(thread: NetworkingThread, freshness: int = 10*24*60*60) -> None:
     """
-    Wait until your chain is no more than 10 days old before you start mining yourself
+    Wait until your chain is no more than specified seconds old before you start mining yourself
     """
-    while thread.local_peer.chain_manager.coinstate.head().timestamp + (10 * 24 * 60 * 60) < time():
+    while thread.local_peer.chain_manager.coinstate.head().timestamp + freshness < time():
         thread.local_peer.show_stats()
-        diff = int(time() - thread.local_peer.chain_manager.coinstate.head().timestamp + (10 * 24 * 60 * 60))
-        print(f"Waiting for fresh chain (your chain is {diff:,} seconds too old for my tastes)")
+        diff = int(time() - thread.local_peer.chain_manager.coinstate.head().timestamp)
+        print(f"Waiting for fresh chain (your chain is {diff:,} seconds, too old for my tastes)")
         sleep(10)
 
 

--- a/skepticoin/wallet.py
+++ b/skepticoin/wallet.py
@@ -87,7 +87,7 @@ class Wallet:
         return sum(
             coinstate.public_key_balances_by_hash[coinstate.current_chain_hash].get(  # type: ignore
                 SECP256k1PublicKey(pk), PKBalance(0, [])).value
-            for pk in self.public_key_annotations.keys()
+            for pk in list(self.public_key_annotations.keys()) + self.unused_public_keys
         )
 
 


### PR DESCRIPTION
This new and improved PR fixes #118 incorrect skepticoin-balance due to two edge-cases:
- outdated chain cache (also partially fixes #117 )
- outdated wallet.json

This has been rebased on master and also, supersedes #123 