### PR TITLE
emergency fixes to revive skepticoin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,14 @@ share
 dist
 skepticoin/scmversion.py
 __pycache__
-**/wallet.json 
-**/peers.json 
-**/chain/ 
+**/wallet.json
+**/peers.json
+**/chain/
 **/chain.cache
+sqlite-autoconf-*
+env*/
+test.db
+test.tmp
+chain.db*
+chain.zip
+.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://gitlab.com/pycqa/flake8
-    rev: '3.9.1'
+-   repo: https://github.com/pycqa/flake8
+    rev: '6.0.0'
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.812'
+    rev: 'v1.2.0'
     hooks:
     -   id: mypy
         files: ^skepticoin/

--- a/extensions/aws-cloud-mining/compute.yaml
+++ b/extensions/aws-cloud-mining/compute.yaml
@@ -72,6 +72,10 @@ Resources:
               Resource: '*'
             - Effect: Allow
               Action:
+              - ec2:DescribeInstances
+              Resource: '*'
+            - Effect: Allow
+              Action:
               - s3:*
               Resource: '*'
               # !ImportValue "PrivateWalletBucket"
@@ -113,7 +117,6 @@ Resources:
           - logs
           - swap
           - workload
-          - crontab
         logs: # send logs to CloudWatch
           files:
             "/etc/cloudwatch-config.json":
@@ -198,19 +201,24 @@ Resources:
                 python3.8 setup.py install
 
                 # prepare skepticoin run-time environment
-                mkdir -p /tmp/skepticoin
-                cd /tmp/skepticoin
+                mkdir -p /home/ec2-user/runtime
+                cd /home/ec2-user/runtime
                 aws s3 cp s3://$PRIVATE_BUCKET/wallet.json .
-                aws s3 cp s3://$PUBLIC_BUCKET/peers.json .
                 aws s3 cp s3://$PUBLIC_BUCKET/chain.db .
 
-                # perform a balance operation first, to update the chain.db and peers.json
-                PYTHONUNBUFFERED=1 skepticoin-balance >> $LOG 2>&1
-                aws s3 sync . s3://$PUBLIC_BUCKET/ --exclude "*" --include chain.db
+                # Publish IP addresses back into peers.json
+                aws ec2 describe-instances --region ${AWS::Region} --filters "Name=tag:Name,Values=skepticoin-miner" "Name=instance-state-name,Values=running" --query 'Reservations[].Instances[].[PublicIpAddress]' --output json | python -c "import sys, json; print(json.dumps([[row[0], 2412, 'OUTGOING'] for row in json.load(sys.stdin)]))" | aws s3 cp --content-type application/json --acl public-read - s3://$PUBLIC_BUCKET/peers.json
+
+                # Set things up to start skepticoin-mine on reboot. Reboot daily, publish chain.db.
+                crontab <<EOF
+                @reboot . /home/ec2-user/venv/bin/activate && cd /home/ec2-user/runtime && PYTHONUNBUFFERED=1 skepticoin-mine ${SkepticoinMiningParams} >> $LOG 2>&1; sleep 1800 && /sbin/reboot
+                0 0 * * * echo 'killall skepticoin-mine; sleep 30; cd /home/ec2-user/runtime && aws s3 sync . s3://$PUBLIC_BUCKET/ --exclude "*" --include chain.db; /sbin/reboot' | at "\$(shuf -i 0-23 -n 1):\$(shuf -i 0-59 -n 1)"
+                EOF
 
                 # start mining
-                PYTHONUNBUFFERED=1 nohup skepticoin-mine ${SkepticoinMiningParams} >> $LOG 2>&1 &
-                echo "miner starting"
+                echo "rebooting to start miner"
+                /sbin/reboot
+
               owner: ec2-user
               group: ec2-user
               mode: "000755"
@@ -220,22 +228,6 @@ Resources:
                 PRIVATE_BUCKET: !ImportValue "PrivateWalletBucket"
                 PUBLIC_BUCKET: !ImportValue "PublicBucket"
               command: /home/ec2-user/workload
-        crontab:
-          files:
-            "/tmp/crontab":
-              # Crontab contents explanation:
-              # - Every 15 minutes check to see if skepticoin-mine is still listening on port 2412. When it's not, it's assumed to have crashed, and the node is taken out.
-              # - Every hour, copy the up-to-date local peers.json back into the public S3 bucket. It'll be overwritten by each node, which is inefficient but fine.
-              content: !Sub
-                - |
-                  */15 * * * * sleep 900; nc -zv 127.0.0.1 2412 || aws autoscaling set-instance-health --region ${AWS::Region} --instance-id $(curl -s http://169.254.169.254/latest/meta-data/instance-id) --health-status Unhealthy
-                  0 * * * * cd /tmp/skepticoin && aws s3 cp peers.json s3://${PUBLIC_BUCKET}/
-                - PUBLIC_BUCKET: !ImportValue "PublicBucket"
-          commands:
-            01_install:
-              command: "yum install -y nc"
-            02_crontab:
-              command: "crontab /tmp/crontab"
 
     Properties:
       AssociatePublicIpAddress: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ immutables==0.15
 pytest-mock==3.6.1
 pytest==6.2.4
 scrypt==0.8.18
+ptpython==3.0.23

--- a/skepticoin/blockstore.py
+++ b/skepticoin/blockstore.py
@@ -205,29 +205,30 @@ class BlockStore:
             (height, previous_block_hash, merkle_root_hash, timestamp, target, nonce,
              pow_summary_hash, pow_chain_sample, pow_block_hash, block_hash) = row
 
-            yield Block(
-                    BlockHeader(
-                        BlockSummary(
-                            height=height,
-                            previous_block_hash=zeroify_nulls(previous_block_hash),
-                            merkle_root_hash=merkle_root_hash,
-                            timestamp=timestamp,
-                            target=target,
-                            nonce=nonce
+            if block_hash in block_builders:
+                yield Block(
+                        BlockHeader(
+                            BlockSummary(
+                                height=height,
+                                previous_block_hash=zeroify_nulls(previous_block_hash),
+                                merkle_root_hash=merkle_root_hash,
+                                timestamp=timestamp,
+                                target=target,
+                                nonce=nonce
+                            ),
+                            PowEvidence(
+                                summary_hash=pow_summary_hash,
+                                chain_sample=pow_chain_sample,
+                                block_hash=pow_block_hash
+                            )
                         ),
-                        PowEvidence(
-                            summary_hash=pow_summary_hash,
-                            chain_sample=pow_chain_sample,
-                            block_hash=pow_block_hash
-                        )
-                    ),
-                    [Transaction(
-                        [v for k, v in sorted(builder.inputs.items(), key=lambda i: i[0])],
-                        [v for k, v in sorted(builder.outputs.items(), key=lambda i: i[0])],
-                        transaction_hash
-                    ) for transaction_hash, builder in block_builders[block_hash]],
-                    hash=block_hash
-            )
+                        [Transaction(
+                            [v for k, v in sorted(builder.inputs.items(), key=lambda i: i[0])],
+                            [v for k, v in sorted(builder.outputs.items(), key=lambda i: i[0])],
+                            transaction_hash
+                        ) for transaction_hash, builder in block_builders[block_hash]],
+                        hash=block_hash
+                )
 
 
 class DefaultBlockStore:

--- a/skepticoin/networking/remote_peer.py
+++ b/skepticoin/networking/remote_peer.py
@@ -467,7 +467,14 @@ class ConnectedRemotePeer(RemotePeer):
                                                human(block_hash)))
                 return
 
-            validate_block_by_itself(block, int(time()))
+            try:
+                validate_block_by_itself(block, int(time()))
+            except Exception as e:
+                self.local_peer.logger.info(
+                    "%15s at height=%d, block received is invalid: %s, error = %s" % (
+                        self.host, coinstate_prior.head().height, human(block_hash), str(e)))
+                return
+
             self.local_peer.disk_interface.save_block(block)
             coinstate_changed = coinstate_prior.add_block_no_validation(block)
 

--- a/skepticoin/scripts/repl.py
+++ b/skepticoin/scripts/repl.py
@@ -25,7 +25,7 @@ class EverythingIsNone:
 
 
 def main() -> None:
-    config_file, history_file = get_config_and_history_file(EverythingIsNone())
+    config_file, history_file = get_config_and_history_file(EverythingIsNone())  # type: ignore
 
     parser = DefaultArgumentParser()
     parser.add_argument("--vi-mode", help="Vi mode", action="store_true")

--- a/skepticoin/scripts/send.py
+++ b/skepticoin/scripts/send.py
@@ -42,7 +42,7 @@ def main() -> None:
     try:
         # we need a fresh chain because our wallet doesn't track spending/receiving, so we need to look at the real
         # blockchain to know what we can spend.
-        wait_for_fresh_chain(thread)
+        wait_for_fresh_chain(thread, freshness=300)
         print("Chain up to date")
 
         target_address = SECP256k1PublicKey(parse_address(args.address))

--- a/skepticoin/scripts/utils.py
+++ b/skepticoin/scripts/utils.py
@@ -28,7 +28,7 @@ def check_chain_dir() -> None:
         print('Your ./chain/ directory is no longer needed: please delete it to stop this reminder.')
 
 
-def wait_for_fresh_chain(thread: NetworkingThread, freshness: int = 10*24*60*60) -> None:
+def wait_for_fresh_chain(thread: NetworkingThread, freshness: int) -> None:
     """
     Wait until your chain is no more than specified seconds old before you start mining yourself
     """
@@ -45,8 +45,8 @@ def read_chain_from_disk() -> CoinState:
     for block in DefaultBlockStore.instance.read_blocks_from_disk():
         try:
             coinstate = coinstate.add_block_no_validation(block)
-        except Exception as e:
-            raise Exception(e, f' @ block_hash={human(block.hash())}, height={block.height}')
+        except Exception:
+            print(f'Skipping block_hash={human(block.hash())} @ height={block.height}')
 
     # It is no longer possible to load old files, due to pickle issues not worth solving.
 


### PR DESCRIPTION
Few people have noticed this, but skepticoin was dead for a few weeks. This PR is a result of resuscitation efforts over the past couple of weeks. I believe the main problem is memory consumption, which increases super-linearly as the blockchain grows. My nodes all crashed due to insufficient memory. This PR does not fix the memory problem, but provides some tools (e.g. the --freshness + eager writes to disk) to help rescue the blockchain if (when?) it dies again.

These are the changes in this PR:
- add --freshness parameter to enable emergency mining on old chain
- flush mined blocks to disk sooner, to guard against unstable peers
- cloud launcher: publish all cloud IPs in S3 peers.json
- cloud launcher: remove balance check to allow mining to start
- ignore errors when loading chain, not sure what happened here