### PR TITLE
fix handling of peers.json to avoid deleting valid peers

### DIFF
--- a/skepticoin/networking/manager.py
+++ b/skepticoin/networking/manager.py
@@ -100,7 +100,6 @@ class NetworkManager(Manager):
                 remote_peer.ban_score += 1
                 self.local_peer.logger.info('%15s Disconnected without hello, ban_score=%d'
                                             % (remote_peer.host, remote_peer.ban_score))
-                self.disk_interface.write_peers(self.connected_peers)
 
             self.disconnected_peers[key] = remote_peer.as_disconnected()
 

--- a/skepticoin/networking/remote_peer.py
+++ b/skepticoin/networking/remote_peer.py
@@ -333,11 +333,12 @@ class ConnectedRemotePeer(RemotePeer):
                                                                     last_connection_attempt=None, ban_score=0)
             nm._sanity_check()
 
+        if self.direction == OUTGOING:
+            self.local_peer.disk_interface.write_peers(self)
+
         if self.direction == OUTGOING and message.nonce == self.local_peer.nonce:
             self.local_peer.network_manager.my_addresses.add((self.host, self.port))
             self.local_peer.disconnect(self, "connection to self")
-
-        self.local_peer.disk_interface.write_peers(self.local_peer.network_manager.connected_peers)
 
     def handle_get_blocks_message_received(self, header: MessageHeader, message: GetBlocksMessage) -> None:
         self.local_peer.logger.info("%15s ConnectedRemotePeer.handle_get_blocks_message_received()" % self.host)

--- a/tests/networking/test_integration.py
+++ b/tests/networking/test_integration.py
@@ -16,7 +16,7 @@ from skepticoin.datatypes import Block, Transaction, Input, Output, OutputRefere
 from skepticoin.coinstate import CoinState
 from skepticoin.networking.messages import InventoryMessage
 from skepticoin.networking.threading import NetworkingThread
-from skepticoin.networking.remote_peer import DisconnectedRemotePeer, load_peers_from_list
+from skepticoin.networking.remote_peer import DisconnectedRemotePeer, RemotePeer, load_peers_from_list
 
 CHAIN_TESTDATA_PATH = Path(__file__).parent.joinpath("../testdata/chain")
 
@@ -25,7 +25,7 @@ class FakeDiskInterface:
     def save_block(self, block):
         pass
 
-    def write_peers(self, remote_peers):
+    def write_peers(self, remote_peer: RemotePeer):
         pass
 
     def load_peers(self) -> Dict[Tuple[str, int, str], DisconnectedRemotePeer]:


### PR DESCRIPTION
While testing some recent code changes, I experienced a recurring issue of peers disappearing from the peers.json, usually following repeated application restarts. This PR fixes the problem by only adding peers to the peers.json when a connection is successful and then only removing them when they exceed a fixed number (100), which should be sufficient for a long time. Also, uses a `os.replace()` to avoid corruption due to partial file writes.